### PR TITLE
Make prop-types a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
     "url": "https://github.com/Storytel/react-redux-spinner/issues"
   },
   "homepage": "https://github.com/Storytel/react-redux-spinner#readme",
+  "dependencies": {
+    "prop-types": "^15.5.7"
+  },
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0 || ^16.0.0",
     "react-dom": "^0.14 || ^15.0.0 || ^16.0.0",
@@ -53,7 +56,6 @@
     "html-webpack-plugin": "^2.12.0",
     "mocha": "^4.0.1",
     "nprogress": "^0.2.0",
-    "prop-types": "^15.5.6",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "redux": "^3.3.1",

--- a/src/webpack.config.babel.js
+++ b/src/webpack.config.babel.js
@@ -11,7 +11,8 @@ const config = [
     ],
     externals: {
       react: 'react',
-      'react-dom': 'ReactDOM'
+      'react-dom': 'ReactDOM',
+      'prop-types': 'PropTypes'
     },
     output: {
       path: path.join(__dirname, '..', 'dist'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -4213,7 +4213,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.10, prop-types@^15.5.6, prop-types@^15.6.0:
+prop-types@^15.5.10, prop-types@^15.5.7, prop-types@^15.6.0:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
   dependencies:


### PR DESCRIPTION
As per [the recommended instructions](https://github.com/facebook/prop-types#how-to-depend-on-this-package) for depending
on the `prop-types` package, do not bundle it, and make it a dependency.

This takes the bundlesize down to a meager 8k!